### PR TITLE
Added connect to the redux store. Add a default merge mergeProps

### DIFF
--- a/packages/airglow-store-react/src/connect.js
+++ b/packages/airglow-store-react/src/connect.js
@@ -18,9 +18,13 @@ export default (mapState = R.identity, mapHandlers = R.identity) => Container =>
   <StoreConsumer>
     {({ state, store }) => (
       <Container
-        {...props}
-        {...mapState(state)}
-        {...mapHandlers(store.dispatch)}
+        {...R.mergeDeepRight(
+          props,
+          R.mergeDeepRight(
+            mapState(state),
+            mapHandlers(store.dispatch)
+          )
+        )}
       />
     )}
   </StoreConsumer>

--- a/packages/airglow-store-react/test/int/__snapshots__/data.storage.test.js.snap
+++ b/packages/airglow-store-react/test/int/__snapshots__/data.storage.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Redux BootstrapIntegrationTest merges nested props 1`] = `
+Object {
+  "details": "meta",
+  "name": "key",
+  "value": "thirteen",
+}
+`;

--- a/packages/airglow-store-react/test/int/data.storage.test.js
+++ b/packages/airglow-store-react/test/int/data.storage.test.js
@@ -20,8 +20,14 @@ const TestComponent = ({ value, onChange }) => (
   <input type="text" value={value || ''} onChange={onChange} />
 );
 const TestConnected = connect(
-  state => ({ value: state.data && state.data.name }),
-  dispatch => ({ onChange: e => dispatch({ type: 'updateName', payload: e.target.value }) })
+  state => ({
+    value: state.data && state.data.name,
+    data: { name: 'key', value: 'eleven' }
+  }),
+  dispatch => ({
+    onChange: e => dispatch({ type: 'updateName', payload: e.target.value }),
+    data: { value: 'thirteen' }
+  })
 )(TestComponent);
 
 const bootstrapConfig = {
@@ -36,7 +42,7 @@ const bootstrapConfig = {
 describe('Redux BootstrapIntegrationTest', () => {
   beforeEach(() => {
     tree = renderAirglow(
-      <TestConnected />,
+      <TestConnected data={{ name: 'props', value: 'six', details: 'meta' }} />,
       {
         store: ReactStore,
         plugins: [],
@@ -55,5 +61,8 @@ describe('Redux BootstrapIntegrationTest', () => {
     tree.unmount();
     const subs = tree.store.subscriptions;
     expect(tree.store.subscriptions[Object.keys(subs)[0]]).toBe(null);
+  });
+  it('merges nested props', () => {
+    expect(tree.find('TestComponent').prop('data')).toMatchSnapshot();
   });
 });

--- a/packages/airglow-store-redux/src/connect.js
+++ b/packages/airglow-store-redux/src/connect.js
@@ -1,0 +1,34 @@
+/*
+ * ************************************************************************
+ * ADOBE CONFIDENTIAL
+ * ___________________
+ *
+ *   Copyright 2019 Adobe Systems Incorporated
+ *   All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Adobe Systems Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Adobe Systems Incorporated and its
+ * suppliers and are protected by all applicable intellectual property
+ * laws, including trade secret and copyright laws.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe Systems Incorporated.
+ * ************************************************************************
+ */
+
+import * as R from 'ramda';
+import { connect } from 'react-redux';
+
+const deepMerge = (stateProps, dispatchProps, ownProps) =>
+  R.mergeDeepRight(
+    ownProps,
+    R.mergeDeepRight(
+      stateProps,
+      dispatchProps
+    )
+  );
+
+export default (mapStateToProps, mapDispatchToProps, mergeProps, options) =>
+  connect(mapStateToProps, mapDispatchToProps, mergeProps || deepMerge, options);

--- a/packages/airglow-store-redux/src/index.js
+++ b/packages/airglow-store-redux/src/index.js
@@ -16,6 +16,8 @@ import { Provider } from 'react-redux';
 import { REDUCER, POST_ENHANCER, ENHANCER, MIDDLEWARE, COMPOSER, HOC } from 'airglow';
 import lazyStore from './lazy.store';
 
+export { default as connect } from './connect';
+
 class StoreFactory {
   create(lookup) {
     this.store = lazyStore(getReducers(lookup), getEnhancers(lookup));

--- a/packages/airglow-store-redux/test/int/__snapshots__/bootstrap.test.js.snap
+++ b/packages/airglow-store-redux/test/int/__snapshots__/bootstrap.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Redux BootstrapIntegrationTest merges nested props 1`] = `
+Object {
+  "details": "meta",
+  "name": "key",
+  "value": "thirteen",
+}
+`;

--- a/packages/airglow-store-redux/test/int/bootstrap.test.js
+++ b/packages/airglow-store-redux/test/int/bootstrap.test.js
@@ -11,18 +11,24 @@ governing permissions and limitations under the License.
 */
 
 import React from 'react';
-import { connect } from 'react-redux';
 import { initialize, slice } from '@airglow/reducers';
 import { renderAirglow } from 'airglow';
-import ReduxStore from '../../src';
+import ReduxStore, { connect } from '../../src';
 
 let tree;
 const TestComponent = ({ text }) => (
   <div>{text}</div>
 );
-const TestConnected = connect(state => (
-  { text: state.data && state.data.bellHopper }
-))(TestComponent);
+const TestConnected = connect(
+  state => ({
+    text: state.data && state.data.bellHopper,
+    data: { name: 'key', value: 'eleven' }
+  }),
+  dispatch => ({
+    onChange: e => dispatch({ type: 'updateName', payload: e.target.value }),
+    data: { value: 'thirteen' }
+  })
+)(TestComponent);
 
 const bootstrapConfig = {
   name: 'bellHopper',
@@ -34,7 +40,7 @@ const bootstrapConfig = {
 describe('Redux BootstrapIntegrationTest', () => {
   beforeEach(() => {
     tree = renderAirglow(
-      <TestConnected />,
+      <TestConnected data={{ name: 'props', value: 'six', details: 'meta' }} />,
       {
         store: ReduxStore,
         plugins: [],
@@ -44,5 +50,8 @@ describe('Redux BootstrapIntegrationTest', () => {
   });
   it('should use the bootsrapped reducers', () => {
     expect(tree).not.toBe(null);
+  });
+  it('merges nested props', () => {
+    expect(tree.find('TestComponent').prop('data')).toMatchSnapshot();
   });
 });

--- a/packages/airglow-store-redux/test/int/store.enhancer.test.js
+++ b/packages/airglow-store-redux/test/int/store.enhancer.test.js
@@ -13,8 +13,7 @@ governing permissions and limitations under the License.
 import React from 'react';
 import { mount } from 'enzyme';
 import Airglow, { ENHANCER } from 'airglow';
-import { connect } from 'react-redux';
-import ReduxStore from '../../src';
+import ReduxStore, { connect } from '../../src';
 
 const testEnhancer = createStore => (...args) => {
   const store = createStore(...args);

--- a/packages/airglow-store-redux/test/int/store.middleware.test.js
+++ b/packages/airglow-store-redux/test/int/store.middleware.test.js
@@ -11,10 +11,9 @@ governing permissions and limitations under the License.
 */
 
 import React from 'react';
-import { connect } from 'react-redux';
 import { mount } from 'enzyme';
 import Airglow, { MIDDLEWARE } from 'airglow';
-import ReduxStore from '../../src';
+import ReduxStore, { connect } from '../../src';
 
 let lastAction;
 let tree;

--- a/packages/airglow-store-redux/test/int/store.reducers.test.js
+++ b/packages/airglow-store-redux/test/int/store.reducers.test.js
@@ -11,12 +11,10 @@ governing permissions and limitations under the License.
 */
 
 import React from 'react';
-import { connect } from 'react-redux';
 import { mount } from 'enzyme';
 
 import Airglow, { REDUCER } from 'airglow';
-import ReduxStore from '../../src';
-
+import ReduxStore, { connect } from '../../src';
 
 const ac = () => ({ type: 'TOGGLE' });
 const reducer = (state, event) => {

--- a/packages/samples/todo-redux/src/containers/form.container.js
+++ b/packages/samples/todo-redux/src/containers/form.container.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { connect } from 'react-redux';
+import { connect } from '@airglow/store-redux';
 import TodoForm from '../components/todo.form';
 import { newTodo, todoList } from '../data/prefabs';
 

--- a/packages/samples/todo-redux/src/containers/list.container.js
+++ b/packages/samples/todo-redux/src/containers/list.container.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { connect } from 'react-redux';
+import { connect } from '@airglow/store-redux';
 import TodoList from '../components/todo.list';
 import { todoList } from '../data/prefabs';
 

--- a/packages/samples/todo-redux/src/containers/main.container.js
+++ b/packages/samples/todo-redux/src/containers/main.container.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '@airglow/store-redux';
 import TodoMain from '../components/todo.main';
 import FormContainer from './form.container';
 import ListContainer from './list.container';


### PR DESCRIPTION
## Motivation and Context

When you have complex components such as a table, it's often nice to wrap all the tables options into a single object. With the default connect, any `mainTable` handlers will override `mainTable` state, which I don't want.

## How Has This Been Tested?

Added a unit test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
