### PR TITLE
If a form value is null in the store, that's probbly on purpose

### DIFF
--- a/packages/prefab-form/src/selectors/select.current.value.js
+++ b/packages/prefab-form/src/selectors/select.current.value.js
@@ -23,7 +23,9 @@ export const getCleanValue = (name, state) => {
 
 // returns the current value in the state. If value is not set
 // it will check for a default value in the construct
-export default R.curry((name, state) => R.defaultTo(
-  getCleanValue(name, state),
-  getStore(name)(state).value
-));
+export default R.curry((name, state) => {
+  const { value } = getStore(name)(state);
+  return value === undefined
+    ? getCleanValue(name, state)
+    : value;
+});

--- a/packages/prefab-form/test/src/selectors/select.current.value.spec.js
+++ b/packages/prefab-form/test/src/selectors/select.current.value.spec.js
@@ -33,6 +33,18 @@ describe('SelectCurrentValue', () => {
     const state = { prefab: { pizza: {
       construct: defaultConstruct
     } } };
+    const state2 = { prefab: { pizza: {
+      construct: fullConstruct,
+      store: { value: undefined }
+    } } };
     expect(selector('pizza', state)).toBe('cheese');
+    expect(selector('pizza', state2)).toBe('hawaiian');
+  });
+  it('should return the value if null', () => {
+    const state = { prefab: { pizza: {
+      construct: fullConstruct,
+      store: { value: null }
+    } } };
+    expect(selector('pizza', state)).toBe(null);
   });
 });


### PR DESCRIPTION
## Motivation and Context

When you are editing a field, you want to temporarily allow null values. For example, let's say I have a number box that is defaulted to 5. Currently, when the the user deletes the 5, it immediately jumps back to 5. It needs to temporarily support the null until the user changes to a new value.

## How Has This Been Tested?
Unit test

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
