### PR TITLE
Fix issue where sort doesnt use the default values on first sort

### DIFF
--- a/packages/prefab-table/src/reducers/sort.reducers.js
+++ b/packages/prefab-table/src/reducers/sort.reducers.js
@@ -14,8 +14,12 @@ import * as R from 'ramda';
 import { hasColumn } from '../selectors/column.selectors';
 
 const sortPath = ['store', 'sort'];
+const defaultSortPath = ['construct', 'defaultSort'];
 
-const getSortState = state => R.path(sortPath, state);
+const getSortState = (state) => {
+  const sort = R.path(sortPath, state);
+  return sort || R.path(defaultSortPath, state);
+}
 
 const sortReducer = (state, { payload }) => {
   const sortState = getSortState(state);

--- a/packages/prefab-table/src/reducers/sort.reducers.js
+++ b/packages/prefab-table/src/reducers/sort.reducers.js
@@ -19,7 +19,7 @@ const defaultSortPath = ['construct', 'defaultSort'];
 const getSortState = (state) => {
   const sort = R.path(sortPath, state);
   return sort || R.path(defaultSortPath, state);
-}
+};
 
 const sortReducer = (state, { payload }) => {
   const sortState = getSortState(state);

--- a/packages/prefab-table/test/src/reducers/__snapshots__/sort.reducers.spec.js.snap
+++ b/packages/prefab-table/test/src/reducers/__snapshots__/sort.reducers.spec.js.snap
@@ -64,3 +64,24 @@ Object {
   },
 }
 `;
+
+exports[`sortReducer should use the default values 1`] = `
+Object {
+  "construct": Object {
+    "columns": Object {
+      "color": Object {},
+      "name": Object {},
+    },
+    "defaultSort": Object {
+      "column": "name",
+      "order": 1,
+    },
+  },
+  "store": Object {
+    "sort": Object {
+      "column": "name",
+      "order": -1,
+    },
+  },
+}
+`;

--- a/packages/prefab-table/test/src/reducers/sort.reducers.spec.js
+++ b/packages/prefab-table/test/src/reducers/sort.reducers.spec.js
@@ -51,6 +51,22 @@ const initState = {
   }
 };
 
+const defaultState = {
+  construct: {
+    columns: {
+      name: {},
+      color: {}
+    },
+    defaultSort: {
+      column: 'name',
+      order: 1
+    }
+  },
+  store: {
+  }
+};
+
+
 describe('sortReducer', () => {
   it('should ignore', function () {
     expect(sortReducer(initState, payload('type')))
@@ -58,6 +74,10 @@ describe('sortReducer', () => {
   });
   it('should set column and order to 1 from empty state', function () {
     expect(sortReducer(initState, payload('name')))
+      .toMatchSnapshot();
+  });
+  it('should use the default values', function () {
+    expect(sortReducer(defaultState, payload('name')))
       .toMatchSnapshot();
   });
   it('should toggle sort order for same column', function () {


### PR DESCRIPTION
## Description

When providing a defaultSort that is ascending, this isn't used in the sortReducer

## How Has This Been Tested?

Unit test written

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
